### PR TITLE
Fix recording and display of Stripe donations to projects

### DIFF
--- a/pages/api/stripe_checkout.ts
+++ b/pages/api/stripe_checkout.ts
@@ -46,6 +46,7 @@ export default async function handler(
         metadata: {
           donor_email: email || null,
           donor_name: name || null,
+          project_slug: project_slug || null,
         },
         success_url: `${req.headers.origin}/thankyou`,
         cancel_url: `${req.headers.origin}/`,
@@ -54,6 +55,7 @@ export default async function handler(
           metadata: {
             donor_email: email || null,
             donor_name: name || null,
+            project_slug: project_slug || null,
           },
         },
       }

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -184,7 +184,7 @@ export async function getServerSideProps({ params }: { params: any }) {
      const crypto = await fetchGetJSONAuthedBTCPay(projects[i].slug)
      xmr = await crypto.xmr
      btc = await crypto.btc
-     usd = await fetchGetJSONAuthedStripe()
+     usd = await fetchGetJSONAuthedStripe(projects[i].slug)
   }
 
     stats[projects[i].slug] = { xmr, btc, usd }

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -144,8 +144,15 @@ export async function fetchGetJSONAuthedStripe() {
     })
     const data = await response.json()
     const dataext = data.data
-    const total = await dataext.reduce((subtotal: number, item: any) => subtotal + Number(item.amount)/100,0)
-    const donations = await dataext.reduce((subtotal: number, item: any) => subtotal + 1,0)
+    let total = 0
+    let donations = 0
+    for(let i=0;i<dataext.length;i++){
+      if (dataext[i].metadata.project_slug == null || dataext[i].metadata.project_slug != slug) {
+        continue
+      }
+      total += Number(dataext[i].amount) / 100
+      donations += 1
+    }
     return await { numdonations: donations, totaldonationsinfiat: total, totaldonations: total }
   } catch (err) {
     if (err instanceof Error) {


### PR DESCRIPTION
This PR fixes two problems:

1) Donations through Stripe did not record which project the donation was intended for.
2) The donation progress info on project pages would show the sum of Stripe donations for all projects instead of showing the Stripe donations for each specific project.