### PR TITLE
Remove payment_method_types

### DIFF
--- a/pages/api/stripe_checkout.ts
+++ b/pages/api/stripe_checkout.ts
@@ -29,7 +29,6 @@ export default async function handler(
       const params: Stripe.Checkout.SessionCreateParams = {
         mode: 'payment',
         submit_type: 'donate',
-        payment_method_types: ['card'],
         currency: CURRENCY,
         line_items: [
           {


### PR DESCRIPTION
By removing payment method types, we can reply on stripe to automatically show the appropriate lower-fee and/or more convenient options for users in their relevant jurisdiction, including bank transfers, Apple Pay, etc. Ref https://docs.stripe.com/api/payment_links/payment_links/create#create_payment_link-payment_method_types