### PR TITLE
Use lazyPaymentMethods in btcpayserver request for static addresses

### DIFF
--- a/pages/api/funding-required.ts
+++ b/pages/api/funding-required.ts
@@ -134,7 +134,10 @@ async function handle(
           }
 
           const { data: invoice } = await btcpayApi.post<BtcPayCreateInvoiceRes>('/invoices', {
-            checkout: { monitoringMinutes: 9999999 },
+            checkout: { 
+              monitoringMinutes: 9999999,
+              lazyPaymentMethods: 'false',
+            },
             currency: CURRENCY,
             metadata,
           })

--- a/pages/api/funding-required.ts
+++ b/pages/api/funding-required.ts
@@ -136,7 +136,7 @@ async function handle(
           const { data: invoice } = await btcpayApi.post<BtcPayCreateInvoiceRes>('/invoices', {
             checkout: { 
               monitoringMinutes: 9999999,
-              lazyPaymentMethods: 'false',
+              lazyPaymentMethods: false,
             },
             currency: CURRENCY,
             metadata,


### PR DESCRIPTION
When generating an invoice for a static donation link, use lazyPaymentMethods=false

https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Invoices_CreateInvoice

boolean Nullable
If true, payment methods are enabled individually upon user interaction in the invoice. Default to store's settings'

This allows us to enable the "only enable the payment method after the user explictly chooses it" setting on the store